### PR TITLE
Use non-minified D3 to fix bower error

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-map-d3",
   "version": "0.1.5",
-  "main": "dist/simple-map-d3.min.js",
+  "main": "dist/simple-map-d3.js",
   "ignore": [
     "node_modules",
     "bower_components",


### PR DESCRIPTION
This fixes the error generated by bower during installation:
```bower                     invalid-meta The "main" field cannot contain minified files```
